### PR TITLE
Fix 'Num Predict Fim' for LMStudio and Oobabooga API

### DIFF
--- a/src/extension/provider-options.ts
+++ b/src/extension/provider-options.ts
@@ -76,7 +76,7 @@ export function createStreamRequestBodyFim(
         prompt,
         stream: true,
         temperature: options.temperature,
-        n_predict: options.numPredictFim
+        max_tokens: options.numPredictFim
       }
     case apiProviders.LlamaCpp:
     case apiProviders.Oobabooga:
@@ -84,7 +84,7 @@ export function createStreamRequestBodyFim(
         prompt,
         stream: true,
         temperature: options.temperature,
-        n_predict: options.numPredictFim
+        max_tokens: options.numPredictFim
       }
     case apiProviders.LiteLLM:
       return {


### PR DESCRIPTION
OpenAI-like APIs expect 'max_tokens' parameter instead of 'n_predict'

Current behavior is:
1. twinny sends:
```
Request body:
{
  "prompt": "<fim_prefix>\nexample:<fim_suffix><fim_middle>",
  "stream": true,
  "temperature": 0.2,
  "n_predict": 128
}
```
2. Oobabooga starts inference with `'max_new_tokens': 16,`

Expected behavior is:
2. Oobabooga starts inference with `'max_new_tokens': 128,`

I'm not sure if the error applies to LMStudio, but I couldn't find any mentions of 'n_predict' in it's APIs.

P.S. I haven't tested this MR 😉 