### PR TITLE
Add FIM template for Codestral-22B

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -195,6 +195,7 @@ export const FIM_TEMPLATE_FORMAT = {
   codegemma: 'codegemma',
   codellama: 'codellama',
   codeqwen: 'codeqwen',
+  codestral: 'codestral',
   custom: 'custom-template',
   deepseek: 'deepseek',
   llama: 'llama',
@@ -215,6 +216,8 @@ export const STOP_DEEPSEEK = [
 export const STOP_STARCODER = ['<|endoftext|>', '<file_sep>']
 
 export const STOP_CODEGEMMA = ['<|file_separator|>', '<|end_of_turn|>', '<eos>']
+
+export const STOP_CODESTRAL = ['[PREFIX]', '[SUFFIX]']
 
 export const DEFAULT_TEMPLATE_NAMES = defaultTemplates.map(({ name }) => name)
 

--- a/src/extension/fim-templates.ts
+++ b/src/extension/fim-templates.ts
@@ -76,7 +76,7 @@ export const getFimPromptTemplateCodestral = ({
     language,
     header
   )
-  return `[SUFFIX]${suffix}[PREFIX]${fileContext}\n${heading}${prefix}`
+  return `${fileContext}\n\n[SUFFIX]${suffix}[PREFIX]${heading}${prefix}`
 }
 
 export const getFimPromptTemplateOther = ({
@@ -131,6 +131,10 @@ function getFimTemplateChosen(format: string, args: FimPromptTemplate) {
 
   if (format === FIM_TEMPLATE_FORMAT.deepseek) {
     return getFimPromptTemplateDeepseek(args)
+  }
+
+  if (format === FIM_TEMPLATE_FORMAT.codestral) {
+    return getFimPromptTemplateCodestral(args)
   }
 
   if (

--- a/src/extension/fim-templates.ts
+++ b/src/extension/fim-templates.ts
@@ -3,7 +3,8 @@ import {
   STOP_DEEPSEEK,
   STOP_LLAMA,
   STOP_STARCODER,
-  STOP_CODEGEMMA
+  STOP_CODEGEMMA,
+  STOP_CODESTRAL
 } from '../common/constants'
 import { supportedLanguages } from '../common/languages'
 import { FimPromptTemplate } from '../common/types'
@@ -61,6 +62,23 @@ export const getFimPromptTemplateDeepseek = ({
   return `<｜fim▁begin｜>${fileContext}\n${heading}${prefix}<｜fim▁hole｜>${suffix}<｜fim▁end｜>`
 }
 
+export const getFimPromptTemplateCodestral = ({
+  context,
+  header,
+  fileContextEnabled,
+  prefixSuffix,
+  language
+}: FimPromptTemplate) => {
+  const { prefix, suffix } = prefixSuffix
+  const { fileContext, heading } = getFileContext(
+    fileContextEnabled,
+    context,
+    language,
+    header
+  )
+  return `[SUFFIX]${suffix}[PREFIX]${fileContext}\n${heading}${prefix}`
+}
+
 export const getFimPromptTemplateOther = ({
   context,
   header,
@@ -88,6 +106,10 @@ function getFimTemplateAuto(fimModel: string, args: FimPromptTemplate) {
 
   if (fimModel.includes(FIM_TEMPLATE_FORMAT.deepseek)) {
     return getFimPromptTemplateDeepseek(args)
+  }
+
+  if (fimModel.includes(FIM_TEMPLATE_FORMAT.codestral)) {
+    return getFimPromptTemplateCodestral(args)
   }
 
   if (
@@ -157,6 +179,10 @@ export const getStopWordsAuto = (fimModel: string) => {
     return STOP_CODEGEMMA
   }
 
+  if (fimModel.includes(FIM_TEMPLATE_FORMAT.codestral)) {
+    return STOP_CODESTRAL
+  }
+
   return STOP_LLAMA
 }
 
@@ -169,6 +195,7 @@ export const getStopWordsChosen = (format: string) => {
   )
     return STOP_STARCODER
   if (format === FIM_TEMPLATE_FORMAT.codegemma) return STOP_CODEGEMMA
+  if (format === FIM_TEMPLATE_FORMAT.codestral) return STOP_CODESTRAL
   return STOP_LLAMA
 }
 


### PR DESCRIPTION
NOT TESTED! I don't have anything set up for creating VSCode extensions (not even TS... compiler?)

### tl;dr: 
I've tried adding Codestral into FIM templates.

BTW, it seems like it's FIM tuning is meh? Or maybe it's a quants issue(5bpw)? Anyway, back to starcoder2-15B.

### Description
This is implementation of Codestral's FIM template.

Template itself is slightly different compared to Continue's implementaion (they use something like `[SUFFIX]{suffix}[PREFIX]{filecontext}{prefix}`) - I've put `fileContext` before `[SUFFIX]` - because as prefix grows Codestral quickly starts to lose suffix's context and use filecontext instead

Also it seems like Codestral prefers `+++++ relative/file.path` as a file header? I don't think I've seen anything about it in official docs though.

I've tested this template directly in oobabooga on `bartowski_Codestral-22B-v0.1-exl2_5_0` (5 bpw model - enough for 24gb with 32k context) (but I've used  `+++++ relative/file.path` as file headers). Tests were very limited, from my findings Codestral:
* heavily respects PREFIX
* respects SUFFIX in easy cases (if PREFIX even slightly contradicts SUFFIX - result won't adhere to SUFFIX)
* often ignores fileContext

Anyway, I haven't tested this code. And I don't mind if it won't be merged - I didn't like Codestral FIM performance anyway :P