### PR TITLE
Add configuration setting to enable/disable completions per-language

### DIFF
--- a/package.json
+++ b/package.json
@@ -288,35 +288,44 @@
           "default": true,
           "description": "Activates or deactivates the Twinny extension."
         },
-        "twinny.autoSuggestEnabled": {
+        "twinny.enabledLanguages": {
           "order": 1,
+          "type": "object",
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "default": {"*": true},
+          "markdownDescription": "Languages to enable completions with Twinny for. `*` is used as the default."
+        },
+        "twinny.autoSuggestEnabled": {
+          "order": 2,
           "type": "boolean",
           "default": true,
           "description": "Enable automatic completion suggestions, manual trigger (default shortcut Alt+\\)."
         },
         "twinny.contextLength": {
-          "order": 2,
+          "order": 3,
           "type": "number",
           "default": 100,
           "description": "Defines the number of lines before and after the current line to include in FIM prompts.",
           "required": true
         },
         "twinny.debounceWait": {
-          "order": 3,
+          "order": 4,
           "type": "number",
           "default": 300,
           "description": "Delay in milliseconds before triggering the next completion.",
           "required": true
         },
         "twinny.temperature": {
-          "order": 4,
+          "order": 5,
           "type": "number",
           "default": 0.2,
           "description": "Sets the model's creativity level (temperature) for generating completions.",
           "required": true
         },
         "twinny.multilineCompletionsEnabled": {
-          "order": 5,
+          "order": 6,
           "type": "boolean",
           "default": true,
           "description": "Experimental feature: enables the generation of multi-line completions."
@@ -325,90 +334,90 @@
           "dependencies": {
             "twinny.multilineCompletionsEnabled": true
           },
-          "order": 6,
+          "order": 7,
           "type": "number",
           "default": 30,
           "description": "Maximum number of lines to use for multi line completions. Applicable only when multilineCompletionsEnabled is enabled."
         },
         "twinny.fileContextEnabled": {
-          "order": 8,
+          "order": 9,
           "type": "boolean",
           "default": false,
           "description": "Enables scanning of neighbouring documents to enhance completion prompts. (Experimental)"
         },
         "twinny.completionCacheEnabled": {
-          "order": 9,
+          "order": 10,
           "type": "boolean",
           "default": false,
           "description": "Caches FIM completions for identical prompts to enhance performance."
         },
         "twinny.numPredictChat": {
-          "order": 10,
+          "order": 11,
           "type": "number",
           "default": 512,
           "description": "Maximum token limit for chat completions.",
           "required": true
         },
         "twinny.numPredictFim": {
-          "order": 11,
+          "order": 12,
           "type": "number",
           "default": 512,
           "description": "Maximum token limit for FIM completions. Set to -1 for no limit. Twinny should stop at logical line breaks.",
           "required": true
         },
         "twinny.enableSubsequentCompletions": {
-          "order": 12,
+          "order": 13,
           "type": "boolean",
           "default": true,
           "description": "Enable this setting to allow twinny to keep making subsequent completion requests to the API after the last completion request was accepted."
         },
         "twinny.ollamaHostname": {
-          "order": 13,
+          "order": 14,
           "type": "string",
           "default": "0.0.0.0",
           "description": "Hostname for Ollama API.",
           "required": true
         },
         "twinny.ollamaApiPort": {
-          "order": 14,
+          "order": 15,
           "type": "number",
           "default": 11434,
           "description": "The API port usually `11434`",
           "required": false
         },
         "twinny.embeddingModel": {
-          "order": 15,
+          "order": 16,
           "type": "string",
           "default": "nomic-embed-text",
           "description": "The embedding model to use (Ollama only)",
           "required": false
         },
         "twinny.keepAlive": {
-          "order": 16,
+          "order": 17,
           "type": "string",
           "default": "5m",
           "description": "Keep models in memory by making requests with keep_alive=-1. Applicable only for Ollama API."
         },
         "twinny.ollamaUseTls": {
-          "order": 17,
+          "order": 18,
           "type": "boolean",
           "default": false,
           "description": "Enables TLS encryption Ollama API connections."
         },
         "twinny.enableLogging": {
-          "order": 18,
+          "order": 19,
           "type": "boolean",
           "default": true,
           "description": "Enable twinny debug mode"
         },
         "twinny.symmetryServerKey": {
-          "order": 19,
+          "order": 20,
           "type": "string",
           "description": "The symmetry master server key.",
           "default": "4b4a9cc325d134dee6679e9407420023531fd7e96c563f6c5d00fd5549b77435"
         },
         "twinny.githubToken": {
-          "order": 27,
+          "order": 28,
           "type": "string",
           "default": "",
           "description": "Your GitHub token. Used for fetching GitHub data."

--- a/src/extension/providers/completion.ts
+++ b/src/extension/providers/completion.ts
@@ -105,6 +105,7 @@ export class CompletionProvider implements InlineCompletionItemProvider {
   private _fileContextEnabled = this._config.get(
     'fileContextEnabled'
   ) as boolean
+  private _enabledLanguages = this._config.get('enabledLanguages') as Record<string, boolean>
   private _usingFimTemplate = false
   private _provider: TwinnyProvider | undefined
 
@@ -140,6 +141,9 @@ export class CompletionProvider implements InlineCompletionItemProvider {
       document,
       position
     )
+
+    const languageEnabled = this._enabledLanguages[document.languageId] ?? this._enabledLanguages['*'] ?? true
+    if (!languageEnabled) return
 
     const cachedCompletion = cache.getCache(this._prefixSuffix)
     if (cachedCompletion && this._completionCacheEnabled) {


### PR DESCRIPTION
The Copilot VSCode extension has the configuration setting `github.copilot.enable`, which allows for enabling or disabling Copilot by language ID. I liked using that to prevent completions for Markdown files (where I just found it distracting).

This PR adds a similar setting for Twinny, called `twinny.enabledLanguages`. When set, it allows for enabling or disabling suggestions by language. Here's an example config I tested locally in my `settings.json`:

```json
{
    "twinny.enabledLanguages": {
        "plaintext": false,
        "markdown": false,
        "mdx": false
    }
}
```

It also renders as a table view in the Settings UI:

![VSCode settings section titled "Twinny: Enabled Languages: Languages to enable completions with Twinny for. `*` is used as the default." The table lists * with the value true, and plaintext, markdown, and mdx with the value false](https://github.com/user-attachments/assets/a77374db-297c-4909-affa-aa389c05565c)

I only tested it with auto-suggestions, so I'm not 100% sure how it interacts when using the "Trigger Inline Suggestion" action explicitly to be honest. I also limited it to basically toggling suggestions in the given file, I didn't make any attempt to e.g. prevent using files with those languages as part of the context or anything