### PR TITLE
allow port to be null

### DIFF
--- a/package.json
+++ b/package.json
@@ -369,7 +369,7 @@
         },
         "twinny.ollamaApiPort": {
           "order": 15,
-          "type": "number",
+          "type": ["number", "null"], 
           "default": 11434,
           "markdownDescription": "Sets the port number for the Ollama API. The default is `11434`, but you can change it if your Ollama instance uses a different port.",
           "required": false

--- a/package.json
+++ b/package.json
@@ -369,7 +369,7 @@
         },
         "twinny.ollamaApiPort": {
           "order": 15,
-          "type": ["number", "null"], 
+          "type": ["number", "null"],
           "default": 11434,
           "markdownDescription": "Sets the port number for the Ollama API. The default is `11434`, but you can change it if your Ollama instance uses a different port.",
           "required": false

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -160,7 +160,7 @@ export type Bracket = (typeof ALL_BRACKETS)[number]
 export interface StreamRequestOptions {
   hostname: string
   path: string
-  port: string | number
+  port?: string | number
   protocol: string
   method: string
   headers: Record<string, string>

--- a/src/extension/api.ts
+++ b/src/extension/api.ts
@@ -9,7 +9,7 @@ export async function streamResponse(request: StreamRequest) {
   const { signal } = controller
 
   try {
-    const url = `${options.protocol}://${options.hostname}:${options.port}${options.path}`
+    const url = `${options.protocol}://${options.hostname}${options.port && options.port !== "0" ? `:${options.port}` : ""}${options.path}`
     const fetchOptions = {
       method: options.method,
       headers: options.headers,
@@ -94,7 +94,7 @@ export async function fetchEmbedding(request: StreamRequest) {
 
 
   try {
-    const url = `${options.protocol}://${options.hostname}:${options.port}${options.path}`
+    const url = `${options.protocol}://${options.hostname}${options.port && options.port !== "0" ? `:${options.port}` : ""}${options.path}`
     const fetchOptions = {
       method: options.method,
       headers: options.headers,

--- a/src/extension/api.ts
+++ b/src/extension/api.ts
@@ -9,7 +9,7 @@ export async function streamResponse(request: StreamRequest) {
   const { signal } = controller
 
   try {
-    const url = `${options.protocol}://${options.hostname}${options.port && options.port !== "0" ? `:${options.port}` : ""}${options.path}`
+    const url = `${options.protocol}://${options.hostname}${options.port ? `:${options.port}` : ""}${options.path}`
     const fetchOptions = {
       method: options.method,
       headers: options.headers,
@@ -94,7 +94,7 @@ export async function fetchEmbedding(request: StreamRequest) {
 
 
   try {
-    const url = `${options.protocol}://${options.hostname}${options.port && options.port !== "0" ? `:${options.port}` : ""}${options.path}`
+    const url = `${options.protocol}://${options.hostname}${options.port ? `:${options.port}` : ""}${options.path}`
     const fetchOptions = {
       method: options.method,
       headers: options.headers,

--- a/src/extension/chat-service.ts
+++ b/src/extension/chat-service.ts
@@ -312,7 +312,7 @@ export class ChatService {
 
     const requestOptions: StreamRequestOptions = {
       hostname: provider.apiHostname,
-      port: Number(provider.apiPort),
+      port: provider.apiPort ? Number(provider.apiPort) : undefined,
       path: provider.apiPath,
       protocol: provider.apiProtocol,
       method: "POST",

--- a/src/extension/conversation-history.ts
+++ b/src/extension/conversation-history.ts
@@ -124,7 +124,7 @@ export class ConversationHistory {
   private getRequestOptions(provider: TwinnyProvider) {
     return {
       hostname: provider.apiHostname,
-      port: Number(provider.apiPort),
+      port: provider.apiPort ? Number(provider.apiPort) : undefined,
       path: provider.apiPath,
       protocol: provider.apiProtocol,
       method: "POST",

--- a/src/extension/provider-manager.ts
+++ b/src/extension/provider-manager.ts
@@ -15,7 +15,7 @@ import { apiProviders, ClientMessage, ServerMessage } from "../common/types"
 export interface TwinnyProvider {
   apiHostname: string
   apiPath: string
-  apiPort: number
+  apiPort?: number
   apiProtocol: string
   id: string
   label: string

--- a/src/extension/providers/completion.ts
+++ b/src/extension/providers/completion.ts
@@ -254,7 +254,7 @@ export class CompletionProvider implements InlineCompletionItemProvider {
 
     const options: StreamRequestOptions = {
       hostname: provider.apiHostname,
-      port: Number(provider.apiPort),
+      port: provider.apiPort ? Number(provider.apiPort) : undefined,
       path: provider.apiPath,
       protocol: provider.apiProtocol,
       method: "POST",

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -732,7 +732,7 @@ export function readGitIgnoreFile(): string[] | undefined {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const logStreamOptions = (opts: any) => {
   const hostname = opts.options?.hostname ?? "unknown"
-  const port = opts.options?.port ?? "unknown"
+  const port = opts.options?.port && opts.options.port !== "0" ? opts.options.port : null
   const body = opts.body ?? {}
   const options = opts.options ?? {}
 
@@ -740,7 +740,7 @@ export const logStreamOptions = (opts: any) => {
 
   const logMessage = `
     ***Twinny Stream Debug***
-    Streaming response from ${hostname}:${port}.
+    Streaming response from ${hostname}${port ? `:${port}` : ""}.
     Request body:
     ${JSON.stringify(body, null, 2)}
 

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -732,7 +732,7 @@ export function readGitIgnoreFile(): string[] | undefined {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const logStreamOptions = (opts: any) => {
   const hostname = opts.options?.hostname ?? "unknown"
-  const port = opts.options?.port && opts.options.port !== "0" ? opts.options.port : null
+  const port = opts.options?.port ?? undefined
   const body = opts.body ?? {}
   const options = opts.options ?? {}
 

--- a/src/webview/providers.tsx
+++ b/src/webview/providers.tsx
@@ -378,7 +378,7 @@ function ProviderForm({ onClose, provider }: ProviderFormProps) {
           <VSCodeTextField
             onChange={handleChange}
             name="apiPort"
-            value={formState.apiPort.toString()}
+            value={formState.apiPort ? formState.apiPort.toString() : ""}
             placeholder='Enter a port e.g "11434"'
           ></VSCodeTextField>
         </div>

--- a/src/webview/providers.tsx
+++ b/src/webview/providers.tsx
@@ -373,10 +373,9 @@ function ProviderForm({ onClose, provider }: ProviderFormProps) {
 
         <div>
           <div>
-            <label htmlFor="apiPort">Port*</label>
+            <label htmlFor="apiPort">Port</label>
           </div>
           <VSCodeTextField
-            required
             onChange={handleChange}
             name="apiPort"
             value={formState.apiPort.toString()}


### PR DESCRIPTION
Fixes #300 
This PR updates the URL construction logic in the streamResponse function to conditionally omit the port value when it is empty,and now it's ok to construct a URL without including the port.