### PR TITLE
Add gitfile to ig

### DIFF
--- a/src/extension/embeddings.ts
+++ b/src/extension/embeddings.ts
@@ -103,6 +103,7 @@ export class EmbeddingDatabase extends Base {
     )
 
     ig.add(embeddingIgnoredGlobs)
+    ig.add([".git", ".gitignore"])
 
     const gitIgnoreFilePath = path.join(rootPath, ".gitignore")
 

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -663,6 +663,7 @@ export async function getAllFilePaths(dirPath: string): Promise<string[]> {
   )
 
   ig.add(embeddingIgnoredGlobs)
+  ig.add([".git", ".gitignore"])
 
   const gitIgnoreFilePath = path.join(rootPath, ".gitignore")
 


### PR DESCRIPTION
The `gitignore` will not ignore `.git` and itself. However, IMO they should be ignored instead of letting users to add them to global settings.
Close #370 