### PR TITLE
Re-ordering embeddingIgnoredGlobs addition for ignore()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "twinny",
-  "version": "3.18.10",
+  "version": "3.18.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "twinny",
-      "version": "3.18.10",
+      "version": "3.18.11",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "twinny",
   "displayName": "twinny - AI Code Completion and Chat",
   "description": "Locally hosted AI code completion plugin for vscode",
-  "version": "3.18.10",
+  "version": "3.18.11",
   "icon": "assets/icon.png",
   "keywords": [
     "code-inference",

--- a/src/extension/embeddings.ts
+++ b/src/extension/embeddings.ts
@@ -97,6 +97,12 @@ export class EmbeddingDatabase extends Base {
 
     const ig = ignore()
 
+    const gitIgnoreFilePath = path.join(rootPath, ".gitignore")
+
+    if (fs.existsSync(gitIgnoreFilePath)) {
+      ig.add(fs.readFileSync(gitIgnoreFilePath).toString())
+    }
+
     const embeddingIgnoredGlobs = this.config.get(
       "embeddingIgnoredGlobs",
       [] as string[]
@@ -104,13 +110,7 @@ export class EmbeddingDatabase extends Base {
 
     ig.add(embeddingIgnoredGlobs)
     ig.add([".git", ".gitignore"])
-
-    const gitIgnoreFilePath = path.join(rootPath, ".gitignore")
-
-    if (fs.existsSync(gitIgnoreFilePath)) {
-      ig.add(fs.readFileSync(gitIgnoreFilePath).toString())
-    }
-
+    
     for (const dirent of dirents) {
       const fullPath = path.join(dirPath, dirent.name)
       const relativePath = path.relative(rootPath, fullPath)


### PR DESCRIPTION
That solves the problem I's discovered with after Ur removal of  FILE_IGNORE_LIST - twinny attempts to embed Maven wrapper in my Java projects again.
Ubiquitous `.gitignore` for Maven projects includes `!.mvn/wrapper/maven-wrapper.jar` that will be happily ingested despite being specified for exclusion in embeddingIgnoredGlobs. Adding embeddingIgnoredGlobs after loading `.gitignore` contents fixes the problem
