### PR TITLE
Add onError to GithubService

### DIFF
--- a/src/extension/review-service.ts
+++ b/src/extension/review-service.ts
@@ -220,6 +220,15 @@ export class GithubService extends ConversationHistory {
             })
             this._completion = ""
           },
+          onError: (error: Error) => {
+            this.webView?.postMessage({
+              type: EVENT_NAME.twinnyOnEnd,
+              value: {
+                error: true,
+                errorMessage: error.message,
+              },
+            } as ServerMessage)
+          }
         })
       } catch (e) {
         return reject(e)


### PR DESCRIPTION
#378 add a error prompt output using onError, and I add the missing onError to GithubService.
Should be merged after #378.