### PR TITLE
Fix#391 fittencode_prevent

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -372,3 +372,9 @@ export const MULTI_LINE_DELIMITERS = ["\n\n", "\r\n\r\n"]
 export const SYMMETRY_EMITTER_KEY = {
   inference: "inference",
 }
+
+//Define an array containing all the error messages that need to be detected when fetch error occurred
+export const knownErrorMessages = [
+"First parameter has member 'readable' that is not a ReadableStream.", //This error occurs When plugins such as Fitten Code are enabled
+"The 'transform.readable' property must be an instance of ReadableStream. Received an instance of h" //When you try to enable the Node.js compatibility mode Compat to solve the problem, this error may pop up
+];

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -3,6 +3,13 @@ import { Base } from "../extension/base"
 export class Logger extends Base {
   private static instance: Logger
 
+  public static ErrorType = {
+    Default: 0, // default color
+    Fetch_Error: 91, // red -- fetch error
+    Abort: 90, // gray -- abort
+    Timeout: 33, // yellow -- timeout
+  };
+
   constructor () {
     super()
   }
@@ -22,6 +29,12 @@ export class Logger extends Base {
   public error = (err: NodeJS.ErrnoException) => {
     if (!this.config.enableLogging) return
     console.error(err.message)
+  }
+
+  public logConsoleError(errorKey: number, message: string, error: Error | string): void {
+    const color = errorKey;
+    const coloredMessage = `\x1b[91m [ERROR_twinny] \x1b[32m Message: ${message} \n \x1b[${color}m Error Type: ${error instanceof Error ? error.name : 'Unknown Error'} \n  Error Message: ${error instanceof Error ? error.message : error} \n \x1b[31m`;
+    console.error(coloredMessage, error);
   }
 }
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,8 +1,29 @@
 import { serverMessageKeys } from "symmetry-core"
-import { InlineCompletionItem, InlineCompletionList, Uri } from "vscode"
+import { InlineCompletionItem, InlineCompletionList, LogLevel, Uri } from "vscode"
 
 import { ALL_BRACKETS } from "./constants"
 import { CodeLanguageDetails } from "./languages"
+
+export const ErrorType = {
+  Default: 0, // default color
+  
+  Fetch_Error: 91, // red -- fetch error
+  Abort: 90,     // gray -- abort
+  Timeout: 33,   // yellow -- timeout
+};
+
+/**
+ * Log error messages in the console with error type and message listed in a specified color , and light red for error details
+ * @param errorKey - The key for the color in the colors object.
+ * @param message - The error message to display.
+ * @param error - The error detail to display in white, can be an Error object or a string.
+ */
+export function logConsoleError(errorKey: number, message: string, error: Error | string): void {
+  const color = errorKey;
+  const coloredMessage = `\x1b[91m [ERROR_twinny] \x1b[32m Message: ${message} \n \x1b[${color}m Error Type： ${error instanceof Error ? error.name : 'Unknown Error'} \n  Error Message： ${error instanceof Error ? error.message  : error} \n \x1b[31m`;
+  const Content = error;
+  console.error(coloredMessage, Content);
+}
 
 export interface RequestBodyBase {
   stream: boolean
@@ -92,6 +113,7 @@ export interface ServerMessage<T = LanguageType> {
     type: string
   }
 }
+
 export interface Message {
   role: string
   content: string | undefined

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -4,26 +4,7 @@ import { InlineCompletionItem, InlineCompletionList, LogLevel, Uri } from "vscod
 import { ALL_BRACKETS } from "./constants"
 import { CodeLanguageDetails } from "./languages"
 
-export const ErrorType = {
-  Default: 0, // default color
-  
-  Fetch_Error: 91, // red -- fetch error
-  Abort: 90,     // gray -- abort
-  Timeout: 33,   // yellow -- timeout
-};
 
-/**
- * Log error messages in the console with error type and message listed in a specified color , and light red for error details
- * @param errorKey - The key for the color in the colors object.
- * @param message - The error message to display.
- * @param error - The error detail to display in white, can be an Error object or a string.
- */
-export function logConsoleError(errorKey: number, message: string, error: Error | string): void {
-  const color = errorKey;
-  const coloredMessage = `\x1b[91m [ERROR_twinny] \x1b[32m Message: ${message} \n \x1b[${color}m Error Type： ${error instanceof Error ? error.name : 'Unknown Error'} \n  Error Message： ${error instanceof Error ? error.message  : error} \n \x1b[31m`;
-  const Content = error;
-  console.error(coloredMessage, Content);
-}
 
 export interface RequestBodyBase {
   stream: boolean

--- a/src/extension/api.ts
+++ b/src/extension/api.ts
@@ -1,6 +1,8 @@
-import { StreamRequest } from "../common/types"
+import { ErrorType,logConsoleError,StreamRequest } from "../common/types"
 
 import { logStreamOptions, safeParseJsonResponse } from "./utils"
+
+import * as vscode from 'vscode';
 
 export async function streamResponse(request: StreamRequest) {
   logStreamOptions(request)
@@ -11,6 +13,7 @@ export async function streamResponse(request: StreamRequest) {
   const timeOut = setTimeout(() => {
     controller.abort()
     onError?.(new Error("Request timed out"))
+    logConsoleError(ErrorType.Timeout, 'Failed to establish connection', new Error("Request timed out"));
   }, 25000)
 
   try {
@@ -89,8 +92,9 @@ export async function streamResponse(request: StreamRequest) {
       if (error.name === "AbortError") {
         onEnd?.()
       } else {
-        console.error("Fetch error:", error)
+        logConsoleError(ErrorType.Fetch_Error, 'Fetch error', error);
         onError?.(error)
+        fitchErrorDetection(error)
       }
     }
   }
@@ -126,7 +130,31 @@ export async function fetchEmbedding(request: StreamRequest) {
 
   } catch (error: unknown) {
     if (error instanceof Error) {
-      console.error("Fetch error:", error)
+      logConsoleError(ErrorType.Fetch_Error, 'Fetch error', error);
+      fitchErrorDetection(error)
     }
+  }
+}
+
+//Define an array containing all the error messages that need to be detected when fetch error occurred
+const knownErrorMessages = [
+  "First parameter has member 'readable' that is not a ReadableStream.", //This error occurs When plugins such as Fitten Code are enabled
+  "The 'transform.readable' property must be an instance of ReadableStream. Received an instance of h" //When you try to enable the Node.js compatibility mode Compat to solve the problem, this error may pop up
+];
+
+function fitchErrorDetection(error: Error) {
+  //Using array matching error
+  if (knownErrorMessages.some(msg => error.message.includes(msg))) {
+    vscode.window.showInformationMessage(
+      "Besides Twinny, there may be other AI extensions being enabled (such as Fitten Code) that are affecting the behavior of the fetch API or ReadableStream used in the Twinny plugin. We recommend that you disable that AI plugin for the smooth use of Twinny",
+      "View extensions",
+      "Restart Vscode (after disabling related extensions)"
+    ).then((selected) => {
+      if (selected === "View extensions") {
+        vscode.commands.executeCommand('workbench.view.extensions');
+      } else if (selected === "Restart Vscode (after disabling related extensions)") {
+        vscode.commands.executeCommand('workbench.action.reloadWindow');
+      }
+    });
   }
 }

--- a/src/extension/chat-service.ts
+++ b/src/extension/chat-service.ts
@@ -377,11 +377,11 @@ export class ChatService extends Base {
       type: EVENT_NAME.twinnyOnEnd,
       value: {
         error: true,
-        errorMessage: error.message,
+        errorMessage: `==## ERROR ##== : ${error.message}`, // Highlight errors on webview
       },
     } as ServerMessage)
   }
-
+  
   private onStreamStart = (controller: AbortController) => {
     this._controller = controller
     commands.executeCommand(

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -3,6 +3,7 @@ import fs from "fs"
 import ignore from "ignore"
 import path from "path"
 import * as util from "util"
+import * as vscode from 'vscode';
 import {
   ColorThemeKind,
   ExtensionContext,
@@ -31,7 +32,8 @@ import {
   QUOTES,
   QUOTES_REGEX,
   SKIP_DECLARATION_SYMBOLS,
-  TWINNY
+  TWINNY,
+  knownErrorMessages
 } from "../common/constants"
 import { supportedLanguages } from "../common/languages"
 import { logger } from "../common/logger"
@@ -762,4 +764,21 @@ const calculateTotalCharacters = (messages: Message[] | undefined): number => {
   return messages.reduce((acc: number, msg: Message) => {
     return acc + (typeof msg.content === "string" ? msg.content.length : 0)
   }, 0)
+}
+
+export function notifyKnownErrors(error: Error) {
+  //Using array matching error
+  if (knownErrorMessages.some(msg => error.message.includes(msg))) {
+    vscode.window.showInformationMessage(
+      "Besides Twinny, there may be other AI extensions being enabled (such as Fitten Code) that are affecting the behavior of the fetch API or ReadableStream used in the Twinny plugin. We recommend that you disable that AI plugin for the smooth use of Twinny",
+      "View extensions",
+      "Restart Visual Studio Code (after disabling related extensions)"
+    ).then((selected) => {
+      if (selected === "View extensions") {
+        vscode.commands.executeCommand('workbench.view.extensions');
+      } else if (selected === "Restart Visual Studio Code (after disabling related extensions)") {
+        vscode.commands.executeCommand('workbench.action.reloadWindow');
+      }
+    });
+  }
 }


### PR DESCRIPTION
In this branch, I mainly conducted corresponding checks on the fetch console content in api.ts. If the corresponding error matches the error in my array (which has occurred during testing and improvement), Vscode will pop up a pop-up window recommending you to close other AI extensions
![屏幕截图 2024-11-14 192746](https://github.com/user-attachments/assets/154d789e-4866-4782-a327-8c828becc37f)
In addition, I have added a new function in the type.ts file that uses ANSI to add corresponding colors to errors in the console for easier observation. I am not sure if this should be added, so I still kept most of the console.error instead of changing it to this function
![image](https://github.com/user-attachments/assets/55347c6f-f82d-4951-851f-c630ae9bccee)
Finally, I slightly adjusted the output of an Error in the Twinny interface to make it easier to recognize. An error occurred instead of Twinny's response
![屏幕截图 2024-11-14 193239](https://github.com/user-attachments/assets/16bfaa0e-5a1c-440c-9c37-e790686cda45)



