### PR TITLE
Fix that empty message following timeout message

### DIFF
--- a/src/extension/api.ts
+++ b/src/extension/api.ts
@@ -16,14 +16,8 @@ export async function streamResponse(request: StreamRequest) {
   const { signal } = controller
 
   const timeOut = setTimeout(() => {
-    controller.abort()
-    onError?.(new Error("Request timed out"))
-    log.logConsoleError(
-      Logger.ErrorType.Timeout,
-      "Failed to establish connection",
-      new Error("Request timed out")
-    )
-  }, 25000)
+    controller.abort(new DOMException("Request timed out", "TimeoutError"))
+  }, 60000)
 
   try {
     const url = `${options.protocol}://${options.hostname}${
@@ -102,6 +96,9 @@ export async function streamResponse(request: StreamRequest) {
     if (error instanceof Error) {
       if (error.name === "AbortError") {
         onEnd?.()
+      } else if (error.name === "TimeoutError") {
+        onError?.(error)
+        log.logConsoleError(Logger.ErrorType.Timeout, "Failed to establish connection", error)
       } else {
         log.logConsoleError(Logger.ErrorType.Fetch_Error, "Fetch error", error)
         onError?.(error)


### PR DESCRIPTION
In the original timeout handling, Twinny used controller.abort(), which threw an AbortError exception for the fetch operation, causing `onEnd?.()` in `streamResponse` to be called.
At the same time, set a longer time (1 min) for timeout.
try to fix #400 