### PR TITLE
fix: preserve chat when returning

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -338,7 +338,7 @@ export interface SelectionContextItem extends ContextItem {
   };
 }
 
-export type AnyContextItem = SelectionContextItem;
+export type AnyContextItem = SelectionContextItem | ContextItem;
 
 export interface MentionType {
   name: string

--- a/src/extension/providers/sidebar.ts
+++ b/src/extension/providers/sidebar.ts
@@ -52,13 +52,13 @@ export class SidebarProvider extends BaseProvider {
 
     webviewView.webview.options = {
       enableScripts: true,
-      localResourceRoots: [this.context?.extensionUri],
+      localResourceRoots: [this.context?.extensionUri]
     }
+
+    this.registerWebView(webviewView.webview)
 
     webviewView.webview.html = this.getHtmlForWebview(webviewView.webview)
     logger.log("Sidebar webview view resolved")
-
-    this.registerWebView(webviewView.webview)
 
     // Reset sidebar ready promise when the Twinny sidebar is hidden (user navigates away)
     webviewView.onDidChangeVisibility(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import {
 } from "./common/constants"
 import { logger } from "./common/logger"
 import {
-  FileContextItem,
+  ContextItem,
   SelectionContextItem,
   ServerMessage} from "./common/types"
 import { setContext } from "./extension/context"
@@ -270,9 +270,9 @@ export async function activate(context: ExtensionContext) {
       const editor = window.activeTextEditor
       if (editor) {
         const filePath = workspace.asRelativePath(editor.document.uri.fsPath)
-        const fileContextItem: FileContextItem = {
+        const fileContextItem: ContextItem = {
           id: filePath, // Use filePath as the ID for files
-          category: "file",
+          category: "files",
           name: path.basename(editor.document.uri.fsPath),
           path: filePath
         }


### PR DESCRIPTION
## Summary
- ensure Twinny sidebar registers webview before rendering so chat state survives navigating away
- fix context item typing to handle file-based items

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891b8e29a288329a03e639da5508cb3