### PR TITLE
Add llmman as a local model provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Twinny is a free AI extension for Visual Studio Code, offering powerful AI-assis
 ## Supported Providers
 
 - localhost OpenAI/Ollama Compatible API (default)
+- [llmman](https://github.com/llmmanorg/llmman)
 - [OpenAI](https://openai.com)
 - [Anthropic](https://www.anthropic.com)
 - [OpenRouter](https://openrouter.ai)

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -17,6 +17,25 @@ These example configurations serve as a starting point. Individual adjustments m
 - **Path:** `/v1/chat/completions`
 - **Model Name:** `codellama:7b-instruct` or any effective instruct model
 
+### llmman
+
+[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API (alongside OpenAI- and Anthropic-compatible ones) on port `17434`. Configure it like Ollama, changing only the port. Start it with `llmman serve` and pull a model with `llmman pull gemma4`.
+
+#### FIM (Auto-complete)
+
+- **Hostname:** `localhost`
+- **Port:** `17434`
+- **Path:** `/api/generate`
+- **Model Name:** `qwen3.8` or any base/code model (e.g. `hf.co/unsloth/Qwen3.5-0.8B-GGUF`)
+- **FIM Template:** Select the appropriate template based on the model.
+
+#### Chat Configuration
+
+- **Hostname:** `localhost`
+- **Port:** `17434`
+- **Path:** `/v1/chat/completions`
+- **Model Name:** `gemma4` or any effective instruct model
+
 ### Open WebUI
 
 Open WebUI can be used a proxy API for twinny, simply configure the endpoint to match what is served by OpenWeb UI.

--- a/src/common/constants/providers.ts
+++ b/src/common/constants/providers.ts
@@ -5,6 +5,8 @@ export const OPEN_AI_COMPATIBLE_PROVIDERS = {
   Oobabooga: "oobabooga",
   OpenWebUI: "openwebui",
   Ollama: "ollama",
+  // https://github.com/llmmanorg/llmman serves the Ollama API on port 17434
+  Llmman: "llmman",
   Twinny: "twinny",
   OpenAICompatible: "openai-compatible"
 }

--- a/src/extension/provider-options.ts
+++ b/src/extension/provider-options.ts
@@ -19,6 +19,7 @@ export function createStreamRequestBodyFim(
     case API_PROVIDERS.OpenAICompatible:
     case API_PROVIDERS.OpenWebUI:
     case API_PROVIDERS.Ollama:
+    case API_PROVIDERS.Llmman:
       return {
         model: options.model,
         prompt,

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -429,6 +429,7 @@ export const getFimDataFromProvider = (
   switch (provider) {
     case API_PROVIDERS.OpenAICompatible:
     case API_PROVIDERS.Ollama:
+    case API_PROVIDERS.Llmman:
     case API_PROVIDERS.OpenWebUI:
       return data?.response
     case API_PROVIDERS.LlamaCpp:

--- a/src/webview/assets/locales/en.json
+++ b/src/webview/assets/locales/en.json
@@ -94,6 +94,7 @@
   "providers-feature-streaming": "Streaming",
   "providers-gemini-name": "Gemini",
   "providers-groq-name": "Groq",
+  "providers-llmman-name": "llmman",
   "providers-mistral-name": "Mistral",
   "providers-ollama-name": "Ollama",
   "providers-openai-compatible-name": "Localhost OpenAI Compatible Server",

--- a/src/webview/default-providers.tsx
+++ b/src/webview/default-providers.tsx
@@ -49,6 +49,19 @@ const providers: TwinnyProvider[] = [
     type: "chat",
   },
   {
+    // https://github.com/llmmanorg/llmman - Ollama-compatible API on 17434
+    label: "providers-llmman-name",
+    logo: <i className="codicon codicon-server" />,
+    apiHostname: "localhost",
+    apiPort: 17434,
+    apiPath: "/v1",
+    apiProtocol: "http",
+    id: "llmman-default",
+    modelName: "gemma4",
+    provider: API_PROVIDERS.Llmman,
+    type: "chat",
+  },
+  {
     label: "providers-openai-compatible-name",
     logo: <SvgOpenAI />,
     apiHostname: "localhost",


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the Ollama API (plus OpenAI- and Anthropic-compatible ones) on port 17434.

- `constants/providers.ts`: add `llmman` to `OPEN_AI_COMPATIBLE_PROVIDERS` so chat/review use the same OpenAI-compatible path as Ollama and it appears in the provider dropdown.
- `provider-options.ts`, `utils.ts`: llmman shares the Ollama `case` for the `/api/generate` FIM body and `data.response` parsing. Embeddings use the existing Ollama `/api/embed` path unchanged.
- `default-providers.tsx`, `locales/en.json`: default chat provider card on `localhost:17434` with the neutral `codicon-server` icon.
- `README.md`, `docs/providers.md`: list llmman and document FIM/chat settings mirroring Ollama.

Not changed: the Ollama-specific `ollamaHostname`/`ollamaApiPort` settings and model dropdown; out of scope for a first pass.

**Testing:** `npm ci`, `npx tsc -p . --noEmit` (1 pre-existing `FileContextItem` error in `src/index.ts`, same before/after), `npx eslint` on changed TS/TSX files (clean). Not run against a live llmman server.

Based on `main` since recent PRs were merged there; happy to retarget.

> AI-assisted, reviewed before submitting.
